### PR TITLE
Check for function first, support for Promise.all

### DIFF
--- a/dist/gsap-then.browser.js
+++ b/dist/gsap-then.browser.js
@@ -1,2 +1,2 @@
 /*! npm.im/gsap-then */
-!function(){"use strict";window.com.greensock.core.Animation.prototype.then=function(n){var t=this;return new Promise(function(n){var e=t.eventCallback("onComplete");t.eventCallback("onComplete",function(){e&&e.apply(this,arguments),n()})}).then(function(){return n(t)})}}();
+!function(){"use strict";window.com.greensock.core.Animation.prototype.then=function(n){var t=this;return new Promise(function(n){var e=t.eventCallback("onComplete");t.eventCallback("onComplete",function(){e&&e.apply(this,arguments),n()})}).then(function(){"function"==typeof n&&n(t)})}}();

--- a/index.js
+++ b/index.js
@@ -7,5 +7,9 @@ window.com.greensock.core.Animation.prototype.then = function (onFullfilled) {
 			}
 			resolve();
 		});
-	}).then(() => onFullfilled(this));
+	}).then(() => {
+		if (typeof onFullfilled === 'function') {
+			onFullfilled(this);
+		}
+	});
 };


### PR DESCRIPTION
This was one of multiple promises I was waiting for via Promise.all, but if I created the promise by calling then() without passing in a function, it threw an error.  It was relatively easy just to pass an empty function in, but I thought I would also add the check to the library so I didn't need to.

I thought if I found it useful, someone else might, so I created a PR.